### PR TITLE
feat: Add OpenRouter support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,11 @@ jobs:
       - run: npm test
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODEL: ${{ secrets.OPENROUTER_MODEL }}
+          OPENROUTER_SITE_URL: ${{ secrets.OPENROUTER_SITE_URL }}
+          OPENROUTER_SITE_NAME: ${{ secrets.OPENROUTER_SITE_NAME }}
+          OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
 
   release-npm:
     needs: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,3 +17,8 @@ jobs:
       - run: npm test
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODEL: ${{ secrets.OPENROUTER_MODEL }}
+          OPENROUTER_SITE_URL: ${{ secrets.OPENROUTER_SITE_URL }}
+          OPENROUTER_SITE_NAME: ${{ secrets.OPENROUTER_SITE_NAME }}
+          OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Check if a number is even using the power of ✨AI✨.
 
-Uses OpenAI's GPT-3.5-turbo model under the hood to determine if a number is even.
+Uses OpenAI or OpenRouter compatible models under the hood to determine if a number is even.
 
 For all those who want to use AI in their product but don't know how.
 
@@ -22,6 +22,8 @@ npm install is-even-ai
 
 ## Usage
 
+You can use convenience functions for quick setup:
+
 ```ts
 import {
   areEqual,
@@ -30,11 +32,22 @@ import {
   isGreaterThan,
   isLessThan,
   isOdd,
-  setApiKey,
+  setOpenAIApiKey,
+  setOpenRouterConfig,
 } from "is-even-ai";
 
-// won't need this if you have OPENAI_API_KEY in your environment
-setApiKey("YOUR_API_KEY");
+// For OpenAI (won't need this if you have OPENAI_API_KEY in your environment)
+// setOpenAIApiKey("YOUR_OPENAI_API_KEY");
+
+// For OpenRouter (won't need this if you have OPENROUTER_API_KEY in your environment)
+setOpenRouterConfig({
+  apiKey: "YOUR_OPENROUTER_API_KEY",
+  // Optional:
+  // siteUrl: "https://your-site.com",
+  // siteName: "Your App Name",
+  // model: "mistralai/mistral-7b-instruct" // Defaults to openai/gpt-3.5-turbo
+});
+
 
 console.log(await isEven(2)); // true
 console.log(await isEven(3)); // false
@@ -50,7 +63,9 @@ console.log(await isLessThan(9, 8)); // false
 console.log(await isLessThan(8, 9)); // true
 ```
 
-for more advance usage like changing which model to use and setting the temperature, use `IsEvenAiOpenAi` instead
+For more advanced usage like changing which model to use and setting the temperature, instantiate the specific AI client class:
+
+### OpenAI
 
 ```ts
 import { IsEvenAiOpenAi } from "is-even-ai";
@@ -58,7 +73,7 @@ import { IsEvenAiOpenAi } from "is-even-ai";
 const isEvenAiOpenAi = new IsEvenAiOpenAi(
   {
     // won't need this if you have OPENAI_API_KEY in your environment
-    apiKey: "YOUR_API_KEY",
+    apiKey: "YOUR_OPENAI_API_KEY",
   },
   {
     model: "gpt-3.5-turbo",
@@ -67,24 +82,42 @@ const isEvenAiOpenAi = new IsEvenAiOpenAi(
 );
 
 console.log(await isEvenAiOpenAi.isEven(2)); // true
-console.log(await isEvenAiOpenAi.isEven(3)); // false
-console.log(await isEvenAiOpenAi.isOdd(4)); // false
-console.log(await isEvenAiOpenAi.isOdd(5)); // true
-console.log(await isEvenAiOpenAi.areEqual(6, 6)); // true
-console.log(await isEvenAiOpenAi.areEqual(6, 7)); // false
-console.log(await isEvenAiOpenAi.areNotEqual(6, 7)); // true
-console.log(await isEvenAiOpenAi.areNotEqual(7, 7)); // false
-console.log(await isEvenAiOpenAi.isGreaterThan(8, 7)); // true
-console.log(await isEvenAiOpenAi.isGreaterThan(7, 8)); // false
-console.log(await isEvenAiOpenAi.isLessThan(8, 9)); // true
-console.log(await isEvenAiOpenAi.isLessThan(9, 8)); // false
+// ... and other methods
 ```
+
+### OpenRouter
+
+```ts
+import { IsEvenAiOpenRouter } from "is-even-ai";
+
+const isEvenAiOpenRouter = new IsEvenAiOpenRouter(
+  {
+    apiKey: "YOUR_OPENROUTER_API_KEY",
+    // Optional:
+    // siteUrl: "https://your-site.com", // Sent as HTTP-Referer
+    // siteName: "Your App Name",       // Sent as X-Title
+    // baseURL: "https://openrouter.ai/api/v1", // Default
+    // model: "mistralai/mistral-7b-instruct" // Default model for IsEvenAiOpenRouter if not specified in chatOptions
+  },
+  {
+    // These are OpenAI.Chat.ChatCompletionCreateParamsStreaming options
+    // model: "openai/gpt-3.5-turbo", // Can override the default model here too
+    temperature: 0,
+  }
+);
+
+console.log(await isEvenAiOpenRouter.isEven(2)); // true
+// ... and other methods
+```
+
+The library will automatically try to use `OPENAI_API_KEY` or `OPENROUTER_API_KEY` (and related `OPENROUTER_SITE_URL`, `OPENROUTER_SITE_NAME`, `OPENROUTER_MODEL`, `OPENROUTER_BASE_URL`) from your environment variables if no API key is explicitly set using the convenience functions. OpenAI is prioritized if both are set.
 
 ## Supported AI platforms
 
 Feel free to make a PR to add more AI platforms.
 
 - [x] [OpenAI](https://openai.com) via `IsEvenAiOpenAi`
+- [x] [OpenRouter](https://openrouter.ai) via `IsEvenAiOpenRouter`
 
 ## Supported methods
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "is-odd",
     "ChatGPT",
     "GPT",
-    "OpenAI"
+    "OpenAI",
+    "OpenRouter"
   ],
   "author": {
     "name": "Calvin Liang",

--- a/src/IsEvenAiOpenRouter.ts
+++ b/src/IsEvenAiOpenRouter.ts
@@ -1,0 +1,73 @@
+import { ClientOptions, OpenAI } from "openai";
+import { IsEvenAiCore, IsEvenAiCorePromptTemplates } from "./IsEvenAiCore";
+
+const SYSTEM_PROMPT =
+  "You are an AI assistant designed to answer questions about numbers. You will only answer with only the word true or false.";
+
+const OpenRouterPromptTemplates = {
+  isEven: (n: number) => `Is ${n} an even number?`,
+  isOdd: (n: number) => `Is ${n} an odd number?`,
+  areEqual: (a: number, b: number) => `Are ${a} and ${b} equal?`,
+  areNotEqual: (a: number, b: number) => `Are ${a} and ${b} not equal?`,
+  isGreaterThan: (a: number, b: number) => `Is ${a} greater than ${b}?`,
+  isLessThan: (a: number, b: number) => `Is ${a} less than ${b}?`,
+} satisfies IsEvenAiCorePromptTemplates;
+
+export interface IsEvenAiOpenRouterConfig {
+  apiKey: string;
+  baseURL?: string;
+  siteUrl?: string;
+  siteName?: string;
+  model?: string;
+}
+
+export class IsEvenAiOpenRouter extends IsEvenAiCore {
+  constructor(
+    config: IsEvenAiOpenRouterConfig,
+    chatOptions: Omit<
+      OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+      "messages" | "stream" | "model"
+    > & { model?: string } = {
+      temperature: 0,
+    }
+  ) {
+    const openAi = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseURL || "https://openrouter.ai/api/v1",
+      defaultHeaders: {
+        ...(config.siteUrl && { "HTTP-Referer": config.siteUrl }),
+        ...(config.siteName && { "X-Title": config.siteName }),
+      },
+    });
+
+    const modelToUse = config.model || chatOptions.model || "openai/gpt-3.5-turbo";
+
+    const query = async (s: string) => {
+      const stream = await openAi.beta.chat.completions.stream({
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: s },
+        ],
+        model: modelToUse,
+        temperature: chatOptions.temperature,
+        ...chatOptions,
+      });
+
+      let response = "";
+      for await (const chunk of stream) {
+        response += chunk.choices[0]?.delta?.content?.toLowerCase() || "";
+
+        if (response.length > 0) {
+          if ("true".startsWith(response)) {
+            return true;
+          } else if ("false".startsWith(response)) {
+            return false;
+          }
+        }
+      }
+      return undefined;
+    };
+
+    super(OpenRouterPromptTemplates, query);
+  }
+}

--- a/src/convenience.ts
+++ b/src/convenience.ts
@@ -1,40 +1,63 @@
 import { IsEvenAiOpenAi } from "./IsEvenAiOpenAi";
+import { IsEvenAiOpenRouter, IsEvenAiOpenRouterConfig } from "./IsEvenAiOpenRouter";
+import { IsEvenAiCore } from "./IsEvenAiCore";
 
-let openAiApiKey: string | undefined;
-let isEvenAiOpenAi: IsEvenAiOpenAi | undefined;
+let activeClient: IsEvenAiCore | undefined;
 
-function getIsEvenAiOpenAi(): IsEvenAiOpenAi {
-  if (!isEvenAiOpenAi) {
-    isEvenAiOpenAi = new IsEvenAiOpenAi({ apiKey: openAiApiKey });
-  }
-
-  return isEvenAiOpenAi;
+export function setOpenAIApiKey(apiKey: string) {
+  activeClient = new IsEvenAiOpenAi({ apiKey });
 }
 
-export function setApiKey(apiKey: string) {
-  openAiApiKey = apiKey;
+export function setOpenRouterConfig(config: IsEvenAiOpenRouterConfig) {
+  activeClient = new IsEvenAiOpenRouter(config);
+}
+
+function getActiveClient(): IsEvenAiCore {
+  if (activeClient) {
+    return activeClient;
+  }
+
+  if (process.env.OPENAI_API_KEY) {
+    setOpenAIApiKey(process.env.OPENAI_API_KEY);
+    return activeClient!;
+  }
+
+  if (process.env.OPENROUTER_API_KEY) {
+    setOpenRouterConfig({
+      apiKey: process.env.OPENROUTER_API_KEY,
+      siteUrl: process.env.OPENROUTER_SITE_URL,
+      siteName: process.env.OPENROUTER_SITE_NAME,
+      model: process.env.OPENROUTER_MODEL,
+      baseURL: process.env.OPENROUTER_BASE_URL,
+    });
+    return activeClient!;
+  }
+
+  throw new Error(
+    "No AI provider API key set. Please call setOpenAIApiKey() or setOpenRouterConfig(), or set OPENAI_API_KEY or OPENROUTER_API_KEY environment variables."
+  );
 }
 
 export function isEven(n: number) {
-  return getIsEvenAiOpenAi().isEven(n);
+  return getActiveClient().isEven(n);
 }
 
 export function isOdd(n: number) {
-  return getIsEvenAiOpenAi().isOdd(n);
+  return getActiveClient().isOdd(n);
 }
 
 export function areEqual(a: number, b: number) {
-  return getIsEvenAiOpenAi().areEqual(a, b);
+  return getActiveClient().areEqual(a, b);
 }
 
 export function areNotEqual(a: number, b: number) {
-  return getIsEvenAiOpenAi().areNotEqual(a, b);
+  return getActiveClient().areNotEqual(a, b);
 }
 
 export function isGreaterThan(a: number, b: number) {
-  return getIsEvenAiOpenAi().isGreaterThan(a, b);
+  return getActiveClient().isGreaterThan(a, b);
 }
 
 export function isLessThan(a: number, b: number) {
-  return getIsEvenAiOpenAi().isLessThan(a, b);
+  return getActiveClient().isLessThan(a, b);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { IsEvenAiCore, IsEvenAiCorePromptTemplates } from "./IsEvenAiCore";
 export { IsEvenAiOpenAi } from "./IsEvenAiOpenAi";
+export { IsEvenAiOpenRouter, IsEvenAiOpenRouterConfig } from "./IsEvenAiOpenRouter";
 
 export {
   areEqual,
@@ -8,5 +9,6 @@ export {
   isGreaterThan,
   isLessThan,
   isOdd,
-  setApiKey,
+  setOpenAIApiKey,
+  setOpenRouterConfig,
 } from "./convenience";

--- a/tests/IsEvenAiOpenRouter.test.ts
+++ b/tests/IsEvenAiOpenRouter.test.ts
@@ -1,0 +1,29 @@
+import { expect, it, vi } from "vitest";
+import { IsEvenAiOpenRouter, IsEvenAiOpenRouterConfig } from "../src/index";
+
+it("should construct and work with OpenRouter config", async () => {
+  if (!process.env.OPENROUTER_API_KEY) {
+    console.warn("Skipping IsEvenAiOpenRouter tests: OPENROUTER_API_KEY not set.");
+    return;
+  }
+
+  const config: IsEvenAiOpenRouterConfig = {
+    apiKey: process.env.OPENROUTER_API_KEY!,
+    model: process.env.OPENROUTER_MODEL || "openai/gpt-3.5-turbo", // Or a known free model like 'mistralai/mistral-7b-instruct'
+    siteName: "is-even-ai-tests",
+  };
+  const isEvenAiOpenRouter = new IsEvenAiOpenRouter(config);
+
+  expect(await isEvenAiOpenRouter.isEven(2)).toBe(true);
+  expect(await isEvenAiOpenRouter.isEven(3)).toBe(false);
+  expect(await isEvenAiOpenRouter.isOdd(4)).toBe(false);
+  expect(await isEvenAiOpenRouter.isOdd(5)).toBe(true);
+  expect(await isEvenAiOpenRouter.areEqual(6, 6)).toBe(true);
+  expect(await isEvenAiOpenRouter.areEqual(6, 7)).toBe(false);
+  expect(await isEvenAiOpenRouter.areNotEqual(6, 7)).toBe(true);
+  expect(await isEvenAiOpenRouter.areNotEqual(7, 7)).toBe(false);
+  expect(await isEvenAiOpenRouter.isGreaterThan(8, 7)).toBe(true);
+  expect(await isEvenAiOpenRouter.isGreaterThan(7, 8)).toBe(false);
+  expect(await isEvenAiOpenRouter.isLessThan(8, 9)).toBe(true);
+  expect(await isEvenAiOpenRouter.isLessThan(9, 8)).toBe(false);
+}, 60000);

--- a/tests/convenience.test.ts
+++ b/tests/convenience.test.ts
@@ -6,10 +6,17 @@ import {
   isGreaterThan,
   isLessThan,
   isOdd,
-  setApiKey,
+  setOpenAIApiKey,
+  setOpenRouterConfig,
 } from "../src/index";
 
-it("should work with key as a environmental variable", async () => {
+it("should work with OpenAI key as an environmental variable", async () => {
+  if (!process.env.OPENAI_API_KEY) {
+    console.warn("Skipping convenience OpenAI env var test: OPENAI_API_KEY not set.");
+    return;
+  }
+  vi.stubEnv("OPENROUTER_API_KEY", ""); // Ensure OpenRouter is not picked up by default
+
   expect(await isEven(2)).toBe(true);
   expect(await isEven(3)).toBe(false);
   expect(await isOdd(4)).toBe(false);
@@ -22,14 +29,66 @@ it("should work with key as a environmental variable", async () => {
   expect(await isGreaterThan(7, 8)).toBe(false);
   expect(await isLessThan(8, 9)).toBe(true);
   expect(await isLessThan(9, 8)).toBe(false);
+  vi.unstubAllEnvs();
 }, 60000);
 
-it("should work with key passed to setKey", async () => {
+it("should work with OpenAI key passed to setOpenAIApiKey", async () => {
+  if (!process.env.OPENAI_API_KEY) {
+    console.warn("Skipping convenience setOpenAIApiKey test: OPENAI_API_KEY not set.");
+    return;
+  }
   const tempOpenAiApiKey = process.env.OPENAI_API_KEY!;
 
   vi.stubEnv("OPENAI_API_KEY", "");
+  vi.stubEnv("OPENROUTER_API_KEY", "");
 
-  setApiKey(tempOpenAiApiKey);
+  setOpenAIApiKey(tempOpenAiApiKey);
+
+  expect(await isEven(2)).toBe(true);
+  expect(await isEven(3)).toBe(false);
+  expect(await isOdd(4)).toBe(false);
+  expect(await isOdd(5)).toBe(true);
+  expect(await areEqual(6, 6)).toBe(true);
+  expect(await areEqual(6, 7)).toBe(false);
+  expect(await areNotEqual(6, 7)).toBe(true);
+  expect(await areNotEqual(7, 7)).toBe(false);
+  expect(await isGreaterThan(8, 7)).toBe(true);
+  expect(await isGreaterThan(7, 8)).toBe(false);
+  expect(await isLessThan(8, 9)).toBe(true);
+  expect(await isLessThan(9, 8)).toBe(false);
+
+  vi.unstubAllEnvs();
+}, 60000);
+
+it("should work with OpenRouter key as an environmental variable", async () => {
+  if (!process.env.OPENROUTER_API_KEY) {
+    console.warn("Skipping convenience OpenRouter env var test: OPENROUTER_API_KEY not set.");
+    return;
+  }
+  vi.stubEnv("OPENAI_API_KEY", ""); // Ensure OpenAI is not picked up by default
+
+  expect(await isEven(22)).toBe(true);
+  expect(await isEven(23)).toBe(false);
+  
+  vi.unstubAllEnvs();
+}, 60000);
+
+
+it("should work with OpenRouter key passed to setOpenRouterConfig", async () => {
+  if (!process.env.OPENROUTER_API_KEY) {
+    console.warn("Skipping convenience setOpenRouterConfig test: OPENROUTER_API_KEY not set.");
+    return;
+  }
+  const tempOpenRouterApiKey = process.env.OPENROUTER_API_KEY!;
+
+  vi.stubEnv("OPENAI_API_KEY", "");
+  vi.stubEnv("OPENROUTER_API_KEY", "");
+
+  setOpenRouterConfig({
+    apiKey: tempOpenRouterApiKey,
+    model: process.env.OPENROUTER_MODEL || "openai/gpt-3.5-turbo",
+    siteName: "is-even-ai-tests-convenience",
+  });
 
   expect(await isEven(2)).toBe(true);
   expect(await isEven(3)).toBe(false);


### PR DESCRIPTION
This commit introduces support for OpenRouter compatible models, allowing users to use alternative AI providers besides OpenAI.

Changes include:
- Added `IsEvenAiOpenRouter` class for OpenRouter integration.
- Updated convenience functions to support OpenRouter configuration.
- Added OpenRouter specific tests.
- Updated README to include OpenRouter usage instructions.
- Added OpenRouter environment variables to GitHub workflows.